### PR TITLE
Added RawResultKFoldValidator

### DIFF
--- a/cross_validation.py
+++ b/cross_validation.py
@@ -107,8 +107,7 @@ class KFoldValidator:
         best_parameters = max(summarized_scores.keys(), key=lambda params: summarized_scores[params])
         return best_parameters, summarized_scores[best_parameters]
 
-    @staticmethod
-    def test(testing, parameters):
+    def test(self, testing, parameters):
         """
         Score the test items using previously determined parameters
         :param testing: A list or tuple of Scored items

--- a/run.py
+++ b/run.py
@@ -13,6 +13,50 @@ formats = {
 }
 
 def main(args):
+    reader = load_data(args)
+
+    # Run cross-validation
+    validator = KFoldValidator(num_folds=args.folds, verbose=args.verbose)
+    scored_test_items = validator.cross_validate(*reader.scored_items(), seed=args.seed)
+
+    # Output results
+    for item in scored_test_items:
+        print('{}\t{}'.format(item, str(scored_test_items[item])))
+    if args.summarize:
+        print('all\t{}'.format(str(validator.summarize(scored_test_items))))
+
+
+def get_args(**extra_args):
+    """
+    Get command line options necessary to run most cross-validation.
+    :param extra_args: Supply each extra argument with all its argparse options as a dict; the argument name is the flag
+    :return: The parsed command line arguments
+    """
+    parser = argparse.ArgumentParser(description='Run cross-validation.')
+    parser.add_argument('-f', '--file', action='append', help='a file representing an item to be included in '
+                                                              'cross-validation; either this or -d must be specified')
+    parser.add_argument('-d', '--directory', action='append', help='a directory of files, each of which is an item to '
+                                                                   'be included in cross-validation; either this or '
+                                                                   '-f must be specified')
+    parser.add_argument('-k', '--folds', help='number of folds to use in cross-validation', default=10)
+    parser.add_argument('-r', '--seed', help='set the random seed for item shuffling', default=random.random())
+    parser.add_argument('-s', '--summarize', action='store_true', help='include summary statistic')
+    parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
+    parser.add_argument('-m', '--metric', help='the metric to optimize for cross-validation; required for some input '
+                                               'formats')
+    parser.add_argument('-i', '--input-format', choices=formats.keys(), help='input file format', default='trec')
+
+    if extra_args:
+        for extra_arg in extra_args:
+            flag = extra_arg.replace('_', '-')
+            parser.add_argument('--{}'.format(flag), **extra_args[extra_arg])
+
+    args = parser.parse_args()
+
+    return args
+
+
+def load_data(args):
     if args.input_format == 'trec' and not args.metric:
         print('Must specify metric for this input format.')
         exit()
@@ -33,30 +77,9 @@ def main(args):
     for file in files:
         reader.read(file, args.metric)
 
-    # Run cross-validation
-    validator = KFoldValidator(args.folds, verbose=args.verbose)
-    scored_test_items = validator.cross_validate(*reader.scored_items(), seed=args.seed)
+    return reader
 
-    # Output results
-    for item in scored_test_items:
-        print('{}\t{}'.format(item, str(scored_test_items[item])))
-    if args.summarize:
-        print('all\t{}'.format(str(validator.summarize(scored_test_items))))
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Run cross-validation.')
-    parser.add_argument('-f', '--file', action='append', help='a file representing an item to be included in '
-                                                              'cross-validation; either this or -d must be specified')
-    parser.add_argument('-d', '--directory', action='append', help='a directory of files, each of which is an item to '
-                                                                   'be included in cross-validation; either this or '
-                                                                   '-f must be specified')
-    parser.add_argument('-k', '--folds', help='number of folds to use in cross-validation', default=10)
-    parser.add_argument('-r', '--seed', help='set the random seed for item shuffling', default=random.random())
-    parser.add_argument('-s', '--summarize', action='store_true', help='include summary statistic')
-    parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
-    parser.add_argument('-m', '--metric', help='the metric to optimize for cross-validation; required for some input '
-                                               'formats')
-    parser.add_argument('-i', '--input-format', choices=formats.keys(), help='input file format', default='trec')
-    args = parser.parse_args()
-
+    args = get_args()
     main(args)

--- a/run_with_raw_output.py
+++ b/run_with_raw_output.py
@@ -1,24 +1,7 @@
 #!/usr/bin/python3
 
-import os
-
-from cross_validation import KFoldValidator
+from cross_validation import RawResultKFoldValidator
 from run import get_args, load_data
-
-
-class RawResultKFoldValidator(KFoldValidator):
-    def __init__(self, raw_dir, num_folds=10, verbose=False):
-        self.raw_dir = raw_dir
-        super().__init__(num_folds=num_folds, verbose=verbose)
-
-    def test(self, testing, parameters):
-        return {item.name: self.read_trec_output(item.name, parameters) for item in testing}
-
-    def read_trec_output(self, query, parameters):
-        infile = os.path.join(self.raw_dir, parameters)
-        with open(infile) as f:
-            raw_results = [line for line in f if query == line.split()[0]]
-        return ''.join(raw_results).strip()
 
 
 def main(args):

--- a/run_with_raw_output.py
+++ b/run_with_raw_output.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python3
+
+import os
+
+from cross_validation import KFoldValidator
+from run import get_args, load_data
+
+
+class RawResultKFoldValidator(KFoldValidator):
+    def __init__(self, raw_dir, num_folds=10, verbose=False):
+        self.raw_dir = raw_dir
+        super(RawResultKFoldValidator, self).__init__(num_folds=num_folds, verbose=verbose)
+
+    def test(self, testing, parameters):
+        return {item.name: self.read_trec_output(item.name, parameters) for item in testing}
+
+    def read_trec_output(self, query, parameters):
+        infile = os.path.join(self.raw_dir, parameters)
+        with open(infile) as f:
+            raw_results = [line for line in f if query == line.split()[0]]
+        return ''.join(raw_results).strip()
+
+
+def main(args):
+    reader = load_data(args)
+
+    # Run cross-validation
+    validator = RawResultKFoldValidator(args.raw_dir, num_folds=args.folds, verbose=args.verbose)
+    scored_test_items = validator.cross_validate(*reader.scored_items(), seed=args.seed)
+
+    for item in scored_test_items:
+        print(scored_test_items[item])
+
+
+if __name__ == '__main__':
+    args = get_args(raw_dir={
+        'help': 'the directory containing the raw results (as opposed to the scored results)',
+        'required': True
+    })
+
+    main(args)

--- a/run_with_raw_output.py
+++ b/run_with_raw_output.py
@@ -9,7 +9,7 @@ from run import get_args, load_data
 class RawResultKFoldValidator(KFoldValidator):
     def __init__(self, raw_dir, num_folds=10, verbose=False):
         self.raw_dir = raw_dir
-        super(RawResultKFoldValidator, self).__init__(num_folds=num_folds, verbose=verbose)
+        super().__init__(num_folds=num_folds, verbose=verbose)
 
     def test(self, testing, parameters):
         return {item.name: self.read_trec_output(item.name, parameters) for item in testing}


### PR DESCRIPTION
In general, this framework requires only the _scores_ of the items to be cross validated. Because of this, it can only give back the per-fold score (and therefore the summary score) for each parameter setting selected by cross validation.

Sometimes you may need to view the raw results from which the scores were calculated, rather than the scores themselves. Since cross-validation may select different optimal parameter settings for each test fold, we need a way to pull items from disparate parameter settings and concatenate them into a single cross validated raw results file.The new RawResultKFoldValidator allows for this by opening each file representing an optimal parameter setting and extracting the results within that file that match the cross validated item.

At present, the run_with_raw_output.py script enables this. In the future, it may be better to incorporate this functionality directly into the main run.py script.